### PR TITLE
feat macros: add interface macros helpers & fix macro-gen naming

### DIFF
--- a/main.c
+++ b/main.c
@@ -28,9 +28,9 @@ void exec_tests() {
 }
 
 void print_formatted_args(int const argc, char const* const argv[]) {
-    string_char formatted_string = utils__format("argc: %d\n", argc);
-    utils__format_print(string_char_data(&formatted_string));
-    string_char_destroy_at(&formatted_string);
+    STRING_TYPE() formatted_string = utils__format("argc: %d\n", argc);
+    utils__format_print(STRING_METHOD(data)(&formatted_string));
+    STRING_METHOD(destroy_at)(&formatted_string);
 
     for (int index = 0u; index < argc; ++index) {
         utils__format_print("argv[%d]: %s\n", index, argv[index]);

--- a/src/construct/numeric_helpers.h
+++ b/src/construct/numeric_helpers.h
@@ -1,19 +1,21 @@
 #pragma once
 
 #include <primitives/unsigned_types_aliases.h>
+#include <utils/macros.h>
 
-// construct_at_#type, construct_copy_at_#type, destroy_at_#type for numeric types
+// TYPE_METHOD(#type, construct_at), TYPE_METHOD(#type, construct_copy_at),
+// TYPE_METHOD(#type, destroy_at) for numeric types
 #define DECLARE_CONSTRUCT_AT_FOR_NUMERIC_TYPE(TYPE) \
-TYPE* TYPE##_construct_at(TYPE* const ptr)
+TYPE* TYPE_METHOD(TYPE, construct_at)(TYPE* const ptr)
 
 #define DECLARE_COPY_CONSTRUCT_AT_FOR_NUMERIC_TYPE(TYPE) \
-TYPE* TYPE##_construct_copy_at(TYPE* const ptr, TYPE const* const src)
+TYPE* TYPE_METHOD(TYPE, construct_copy_at)(TYPE* const ptr, TYPE const* const src)
 
 #define DECLARE_MOVE_CONSTRUCT_AT_FOR_NUMERIC_TYPE(TYPE) \
-TYPE* TYPE##_construct_move_at(TYPE* const ptr, TYPE* const src)
+TYPE* TYPE_METHOD(TYPE, construct_move_at)(TYPE* const ptr, TYPE* const src)
 
 #define DECLARE_DESTROY_AT_FOR_NUMERIC_TYPE(TYPE) \
-void TYPE##_destroy_at(TYPE* const ptr)
+void TYPE_METHOD(TYPE, destroy_at)(TYPE* const ptr)
 
 #define DECLARE_CONSTRUCTORS_AND_DESTRUCTORS_FOR_NUMERIC_TYPE(TYPE) \
 DECLARE_CONSTRUCT_AT_FOR_NUMERIC_TYPE(TYPE);\
@@ -22,24 +24,24 @@ DECLARE_MOVE_CONSTRUCT_AT_FOR_NUMERIC_TYPE(TYPE);\
 DECLARE_DESTROY_AT_FOR_NUMERIC_TYPE(TYPE)
 
 #define IMPLEMENT_CONSTRUCT_AT_FOR_NUMERIC_TYPE(TYPE) \
-TYPE* TYPE##_construct_at(TYPE* const ptr) { \
+TYPE* TYPE_METHOD(TYPE, construct_at)(TYPE* const ptr) { \
 	*ptr = 0; \
 	return ptr; \
 }
 
 #define IMPLEMENT_COPY_CONSTRUCT_AT_FOR_NUMERIC_TYPE(TYPE) \
-TYPE* TYPE##_construct_copy_at(TYPE* const ptr, TYPE const* const src) { \
+TYPE* TYPE_METHOD(TYPE, construct_copy_at)(TYPE* const ptr, TYPE const* const src) { \
 	*ptr = *src; \
 	return ptr; \
 }
 
 #define IMPLEMENT_MOVE_CONSTRUCT_AT_FOR_NUMERIC_TYPE(TYPE) \
-TYPE* TYPE##_construct_move_at(TYPE* const ptr, TYPE* const src) { \
-	return TYPE##_construct_copy_at(ptr, src); \
+TYPE* TYPE_METHOD(TYPE, construct_move_at)(TYPE* const ptr, TYPE* const src) { \
+	return TYPE_METHOD(TYPE, construct_copy_at)(ptr, src); \
 }
 
 #define IMPLEMENT_DESTROY_AT_FOR_NUMERIC_TYPE(TYPE) \
-void TYPE##_destroy_at(TYPE* const ptr) {}
+void TYPE_METHOD(TYPE, destroy_at)(TYPE* const ptr) {}
 
 #define IMPLEMENT_CONSTRUCTORS_AND_DESTRUCTORS_FOR_NUMERIC_TYPE(TYPE) \
 IMPLEMENT_CONSTRUCT_AT_FOR_NUMERIC_TYPE(TYPE);\

--- a/src/utils/format.c
+++ b/src/utils/format.c
@@ -37,18 +37,18 @@ struct LOCAL_NAMESPACE(pattern)* PATTERN_FN(construct_at)(struct LOCAL_NAMESPACE
 struct LOCAL_NAMESPACE(pattern)* PATTERN_FN(construct_copy_at)(struct LOCAL_NAMESPACE(pattern) * const this, struct LOCAL_NAMESPACE(pattern) const* const src) {
     ASSERT(this);
     ASSERT(src);
-    string_char_construct_copy_at(&this->_string_representation, &src->_string_representation);
+    STRING_METHOD(construct_copy_at)(&this->_string_representation, &src->_string_representation);
     this->_type = src->_type;
     return this;
 }
 void PATTERN_FN(destroy_at)(struct LOCAL_NAMESPACE(pattern) * const this) {
     ASSERT(this);
-    string_char_destroy_at(&this->_string_representation);
+    STRING_METHOD(destroy_at)(&this->_string_representation);
 }
 
 struct LOCAL_NAMESPACE(pattern)* PATTERN_FN(construct_with_values_at)(struct LOCAL_NAMESPACE(pattern) * const this,
     enum LOCAL_NAMESPACE(format_string_pattern_type) type, char const* const pattern_string_representation) {
-    string_char_construct_from_c_string_at(&this->_string_representation, pattern_string_representation);
+    STRING_METHOD(construct_from_c_string_at)(&this->_string_representation, pattern_string_representation);
     this->_type = type;
     return this;
 }
@@ -114,7 +114,7 @@ struct LOCAL_NAMESPACE(format_string_pattern_occurrence_index) LOCAL_NAMESPACE(s
             result._pattern = VECTOR_OF_PATTERNS_FN(at)(&patterns->_patterns, vec_index);
             if (!utils__string__compare_string_char_with_buffer(
                 &result._pattern->_string_representation,
-                string_char_size(&result._pattern->_string_representation),
+                STRING_METHOD(size)(&result._pattern->_string_representation),
                 format_string + result._index)
             ) {
                 return result;
@@ -128,15 +128,15 @@ struct LOCAL_NAMESPACE(format_string_pattern_occurrence_index) LOCAL_NAMESPACE(s
 struct string_char NAMESPACE(format)(char const* const format_string, ...) {
     va_list args;
     va_start(args, format_string);
-    struct string_char result = NAMESPACE(va_format)(format_string, args);
+    struct STRING_TYPE() result = NAMESPACE(va_format)(format_string, args);
     va_end(args);
 
     return result;
 }
 
 struct string_char NAMESPACE(va_format)(char const* const format_string, va_list args) {
-    string_char formatted_string;
-    string_char_construct_at(&formatted_string);
+    struct STRING_TYPE() formatted_string;
+    STRING_METHOD(construct_at)(&formatted_string);
 
     struct LOCAL_NAMESPACE(patterns) patterns;
     PATTERNS_FN(construct_at)(&patterns);
@@ -145,7 +145,7 @@ struct string_char NAMESPACE(va_format)(char const* const format_string, va_list
         LOCAL_NAMESPACE(format_string_pattern_occurrence_index) pattern_n_index = LOCAL_NAMESPACE(search_pattern_occurence)(format_string + format_string_index, &patterns);
         // copy passed substring from format_string
         for (uint index = 0u; index < pattern_n_index._index; ++index, ++format_string_index) {
-            string_char_push_back(&formatted_string, &format_string[format_string_index]);
+            STRING_METHOD(push_back)(&formatted_string, &format_string[format_string_index]);
         }
         LOCAL_NAMESPACE(pattern) const* const pattern = pattern_n_index._pattern;
         // stop if no patterns matched
@@ -155,27 +155,27 @@ struct string_char NAMESPACE(va_format)(char const* const format_string, va_list
         switch (pattern->_type) {
             case ESCAPED_PERCENT: {
                 char value = '%';
-                string_char_push_back(&formatted_string, &value);
+                STRING_METHOD(push_back)(&formatted_string, &value);
             } break;
             case CHARACTER: {
                 char value = va_arg(args, int);
-                string_char_push_back(&formatted_string, &value);
+                STRING_METHOD(push_back)(&formatted_string, &value);
             } break;
             case NULL_TERMINATED_STRING: {
                 char const* const null_terminated_string = va_arg(args, char*);
                 for (uint index = 0u; null_terminated_string[index] != '\0'; ++index) {
-                    string_char_push_back(&formatted_string, &null_terminated_string[index]);
+                    STRING_METHOD(push_back)(&formatted_string, &null_terminated_string[index]);
                 }
             } break;
             case SIGNED_INTEGER_TO_DECIMAL: {
                 string_char result = utils__string__int_to_string_char(va_arg(args, int));
-                for (uint index = 0u; index < string_char_size(&result); ++index) {
-                    string_char_push_back(&formatted_string, string_char_at(&result, index));
+                for (uint index = 0u; index < STRING_METHOD(size)(&result); ++index) {
+                    STRING_METHOD(push_back)(&formatted_string, STRING_METHOD(at)(&result, index));
                 }
-                string_char_destroy_at(&result);
+                STRING_METHOD(destroy_at)(&result);
             } break;
         }
-        format_string_index += string_char_size(&pattern->_string_representation);
+        format_string_index += STRING_METHOD(size)(&pattern->_string_representation);
     }
     PATTERNS_FN(destroy_at)(&patterns);
 

--- a/src/utils/macros.h
+++ b/src/utils/macros.h
@@ -6,20 +6,205 @@
 #define CONCAT4(NAME1, NAME2, NAME3, NAME4) CONCAT2(CONCAT3(NAME1, NAME2, NAME3), NAME4)
 #define CONCAT5(NAME1, NAME2, NAME3, NAME4, NAME5) CONCAT4(CONCAT2(NAME1, NAME2), NAME3, NAME4, NAME5)
 
-#define TYPE_METHOD(TYPE, METHOD) CONCAT3(TYPE, _, METHOD)
-#define FUNCTION_FOR_TYPE(FUNCTION, TYPE) CONCAT3(FUNCTION, _, TYPE)
-
 #define STRINGIFY_(VALUE) #VALUE
 #define STRINGIFY(VALUE) STRINGIFY_(VALUE)
 
+#define TYPE_METHOD(TYPE, METHOD) CONCAT3(TYPE, __, METHOD)
+#define TYPE_MEMBER(TYPE, MEMBER) CONCAT3(TYPE, __, MEMBER)
+#define FUNCTION_FOR_TYPE(FUNCTION, TYPE) CONCAT3(FUNCTION, __, TYPE)
+
+#define NOT_NULL(NAME) CONCAT3(not_null, __, NAME)
+
+// interfaces' macro helpers definitions
+#define TYPE_DYNAMIC_METHOD(TYPE, METHOD) CONCAT5(TYPE, __, dynamic, __, METHOD)
+
+#define INTERFACE_TYPE(INTERFACE_NAME) CONCAT3(INTERFACE_NAME, __, interface)
+#define INTERFACE_VARIABLE(INTERFACE_NAME) CONCAT3(INTERFACE_NAME, _, interface)
+
+#define INTERFACE_VTABLE_TYPE(INTERFACE_NAME) CONCAT3(INTERFACE_NAME, __, virtual_table)
+#define INTERFACE_VTABLE_VARIABLE(INTERFACE_NAME) CONCAT3(INTERFACE_NAME, _, virtual_table)
+
+#define INTERFACE_GETTER(TYPE_NAME, INTERFACE_NAME) TYPE_METHOD(TYPE_NAME, CONCAT3(get, _, INTERFACE_VARIABLE(INTERFACE_NAME)))
+#define INTERFACE_METHOD_GETTER(INTERFACE_NAME, INTERFACE_METHOD, INTERFACE_VARIABLE) (INTERFACE_VARIABLE).INTERFACE_VTABLE_VARIABLE(INTERFACE_NAME)->INTERFACE_METHOD
+
+// interfaces' macro boilerplates
+#define DEFINE_INTERFACE_VTABLE_ADAPTER(INTERFACE_NAME)\
+struct INTERFACE_VTABLE_TYPE(INTERFACE_NAME) const*/*const*/ INTERFACE_VTABLE_VARIABLE(INTERFACE_NAME)
+
+#define DEFINE_INTERFACE_ADAPTER(INTERFACE_NAME)\
+struct INTERFACE_TYPE(INTERFACE_NAME)/*const*/ INTERFACE_VARIABLE(INTERFACE_NAME)
+
+#define DEFINE_INTERFACE_TYPE_DYNAMIC_DISPOSE_METHODS(INTERFACE_NAME)\
+inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(INTERFACE_NAME), destroy_at)(struct INTERFACE_TYPE(INTERFACE_NAME)* const interface) {\
+    interface->INTERFACE_VTABLE_VARIABLE(INTERFACE_NAME)->destroy_at(interface);\
+}\
+inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(INTERFACE_NAME), deallocate_at)(struct INTERFACE_TYPE(INTERFACE_NAME)* const interface) {\
+    interface->INTERFACE_VTABLE_VARIABLE(INTERFACE_NAME)->deallocate_at(interface);\
+}
+
+/*
+* Inteface macros usage example:
+* on_click_interface.h
+* * #pragma once
+* * #include "utils/macros.h"
+* *
+* * struct INTERFACE_TYPE(OnClick);
+* * 
+* * struct INTERFACE_VTABLE_TYPE(OnClick) {
+* *     void (*click)(struct INTERFACE_TYPE(OnClick)* const this);
+* *     void (*destroy_at)(struct INTERFACE_TYPE(OnClick)* const this);
+* *     void (*deallocate_at)(struct INTERFACE_TYPE(OnClick)* const this);
+* * };
+* * 
+* * struct INTERFACE_TYPE(OnClick) {
+* *     DEFINE_INTERFACE_VTABLE_ADAPTER(OnClick);
+* * };
+* * 
+* * struct INTERFACE_TYPE(OnClick)* TYPE_METHOD(INTERFACE_TYPE(OnClick), construct_at)(struct INTERFACE_TYPE(OnClick)* const this);
+* * void TYPE_MEMBER(INTERFACE_TYPE(OnClick), destroy_at)(struct INTERFACE_TYPE(OnClick)* const this);
+* * void TYPE_MEMBER(INTERFACE_TYPE(OnClick), deallocate_at)(struct INTERFACE_TYPE(OnClick)* const this);
+* * 
+* * inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(OnClick), click)(struct INTERFACE_TYPE(OnClick)* const this) {
+* *     this->INTERFACE_VTABLE_VARIABLE(OnClick)->click(this);
+* * }
+* * 
+* * DEFINE_INTERFACE_TYPE_DYNAMIC_DISPOSE_METHODS(OnClick);
+* *
+* on_click_interface.c
+* * #include "on_click_interface.h"
+* *
+* * #include <stddef.h>
+* * #include <stdlib.h>
+* * #include <stdio.h>
+* * 
+* * void TYPE_MEMBER(INTERFACE_TYPE(OnClick), destroy_at)(struct INTERFACE_TYPE(OnClick)* const this) {
+* *     // method body
+* *     // ...
+* * }
+* * 
+* * void TYPE_MEMBER(INTERFACE_TYPE(OnClick), deallocate_at)(struct INTERFACE_TYPE(OnClick)* const this) {
+* *     free(this);
+* * }
+* * 
+* * static struct INTERFACE_VTABLE_TYPE(OnClick) TYPE_MEMBER(INTERFACE_TYPE(OnClick), INTERFACE_VTABLE_VARIABLE(OnClick)) = {
+* *     .click = NULL,
+* *     .destroy_at = TYPE_MEMBER(INTERFACE_TYPE(OnClick), destroy_at),
+* *     .deallocate_at = TYPE_MEMBER(INTERFACE_TYPE(OnClick), deallocate_at)
+* * };
+* * 
+* * struct INTERFACE_TYPE(OnClick)* TYPE_METHOD(INTERFACE_TYPE(OnClick), construct_at)(struct INTERFACE_TYPE(OnClick)* const this) {
+* *     // boilerplate
+* *     this->INTERFACE_VTABLE_VARIABLE(OnClick) = &TYPE_MEMBER(INTERFACE_TYPE(OnClick), INTERFACE_VTABLE_VARIABLE(OnClick));
+* * 
+* *     // method body
+* *     // ...
+* * }
+* *
+* button.h
+* * #pragma once
+* * #include "on_click_interface.h"
+* * struct Button {
+* *     DEFINE_INTERFACE_ADAPTER(OnClick);
+* * };
+* * 
+* * struct Button* TYPE_METHOD(Button, construct_at)(struct Button* const this);
+* * struct INTERFACE_TYPE(OnClick)* INTERFACE_GETTER(Button, OnClick)(struct Button* const this);
+* * void TYPE_METHOD(Button, destroy_at)(struct Button* const this);
+* * inline static void TYPE_DYNAMIC_METHOD(Button, destroy_at)(struct Button* const this) {
+* *     // any interface with destroy_at is appropriate
+* *     TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(OnClick), destroy_at)(INTERFACE_GETTER(Button, OnClick)(this));
+* * }
+* * void TYPE_METHOD(Button, deallocate_at)(struct Button* const this);
+* * inline static void TYPE_DYNAMIC_METHOD(Button, deallocate_at)(struct Button* const this) {
+* *     // any interface with deallocate_at is appropriate
+* *     TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(OnClick), deallocate_at)(INTERFACE_GETTER(Button, OnClick)(this));
+* * }
+* *
+* button.c
+* * #include "button.h"
+* * #include <stddef.h>
+* * #include <stdlib.h>
+* * #include <stdio.h>
+* * 
+* * void TYPE_METHOD(Button, destroy_at)(struct Button* const this) {
+* *     printf("Button class destructor called\n");
+* * 
+* *     TYPE_METHOD(INTERFACE_TYPE(OnClick), destroy_at)(&this->INTERFACE_VARIABLE(OnClick));
+* * }
+* * 
+* * void TYPE_METHOD(Button, deallocate_at)(struct Button* const this) {
+* *     free(this);
+* * }
+* * 
+* * // OnClick overloading
+* * // fully boilerplated destroy_at
+* * static void TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), destroy_at))(struct INTERFACE_TYPE(OnClick)* const interface) {
+* *     TYPE_METHOD(Button, destroy_at)((struct Button* const)((void*)interface - offsetof(struct Button, INTERFACE_VARIABLE(OnClick))));
+* * }
+* * 
+* * // fully boilerplated deallocate_at
+* * void TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), deallocate_at))(struct INTERFACE_TYPE(OnClick)* const interface) {
+* *     struct Button* const this = (struct Button* const)((void*)interface - offsetof(struct Button, INTERFACE_VARIABLE(OnClick)));
+* *     TYPE_METHOD(Button, deallocate_at)(this);
+* * }
+* * 
+* * void TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), click))(struct INTERFACE_TYPE(OnClick)* const interface) {
+* *     // boilerplate
+* *     struct Button* const this = (struct Button* const)((void*)interface - offsetof(struct Button, INTERFACE_VARIABLE(OnClick)));
+* *     // method body
+* *     printf("Button clicked\n");
+* * }
+* * 
+* * static struct INTERFACE_VTABLE_TYPE(OnClick) CONCAT3(Button, _, INTERFACE_VTABLE_VARIABLE(OnClick)) = {
+* *     .click = &TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), click)),
+* *     .destroy_at = &TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), destroy_at)),
+* *     .deallocate_at = &TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), deallocate_at))
+* * };
+* * 
+* * struct INTERFACE_TYPE(OnClick)* INTERFACE_GETTER(Button, OnClick)(struct Button* const this) {
+* *     return &this->INTERFACE_VARIABLE(OnClick);
+* * }
+* * 
+* * // Button class non-virtual methods
+* * struct Button* TYPE_METHOD(Button, construct_at)(struct Button* const this) {
+* *     // boilerplate
+* *     TYPE_METHOD(INTERFACE_TYPE(OnClick), construct_at)(&this->INTERFACE_VARIABLE(OnClick));
+* *     // methods overloading via vtable change
+* *     INTERFACE_GETTER(Button, OnClick)(this)->INTERFACE_VTABLE_VARIABLE(OnClick) = &CONCAT3(Button, _, INTERFACE_VTABLE_VARIABLE(OnClick));
+* *     // method body
+* *     printf("Button class constructor called\n");
+* * 
+* *     return this;
+* * }
+* * 
+* main.c
+* * #include "button.h"
+* * 
+* * int main() {
+* *     struct Button button;
+* *     TYPE_METHOD(Button, construct_at)(&button);
+* * 
+* *     // call derived object's click method override via OnClick interface method click calling
+* *     {
+* *         struct INTERFACE_TYPE(OnClick)* const interface = INTERFACE_GETTER(Button, OnClick)(&button);
+* *         TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(OnClick), click)(interface);
+* *     }
+* * 
+* *     // destroy derived object via OnClick interface destructor calling
+* *     {
+* *         struct INTERFACE_TYPE(OnClick)* const interface = INTERFACE_GETTER(Button, OnClick)(&button);
+* *         TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(OnClick), destroy_at)(interface);
+* *     }
+* * 
+* *     return 0;
+* * }
+* * 
+*/
+
 #ifdef DEBUG
+	#include <assert.h>
 
-#include <assert.h>
-
-#define ASSERT(EXPR) assert(EXPR)
-
+	#define ASSERT(EXPR) assert(EXPR)
 #else
-
-#define ASSERT(EXPR)
-
+	#define ASSERT(EXPR)
 #endif

--- a/src/utils/string/helpers.h
+++ b/src/utils/string/helpers.h
@@ -7,32 +7,32 @@
 #include <containers/string.h>
 
 #define DECLARE_NUMERIC_TYPE_TO_STRING_TYPE(NUMERIC_TYPE, CHAR_TYPE)\
-struct string_##CHAR_TYPE utils__string__##NUMERIC_TYPE##_to_string_##CHAR_TYPE(NUMERIC_TYPE value)
+struct SPECIALIZED_STRING_TYPE(CHAR_TYPE) utils__string__##NUMERIC_TYPE##_to_string_##CHAR_TYPE(NUMERIC_TYPE value)
 #define IMPLEMENT_NUMERIC_TYPE_TO_STRING_TYPE(NUMERIC_TYPE, CHAR_TYPE)\
-struct string_##CHAR_TYPE utils__string__##NUMERIC_TYPE##_to_string_##CHAR_TYPE(NUMERIC_TYPE value) {\
-    struct string_##CHAR_TYPE result;\
-    string_##CHAR_TYPE##_construct_at(&result);\
+struct SPECIALIZED_STRING_TYPE(CHAR_TYPE) utils__string__##NUMERIC_TYPE##_to_string_##CHAR_TYPE(NUMERIC_TYPE value) {\
+    struct SPECIALIZED_STRING_TYPE(CHAR_TYPE) result;\
+    SPECIALIZED_STRING_METHOD(CHAR_TYPE, construct_at)(&result);\
     if (!value) {\
         CHAR_TYPE const letter = '0';\
-        string_##CHAR_TYPE##_push_back(&result, &letter);\
+        SPECIALIZED_STRING_METHOD(CHAR_TYPE, push_back)(&result, &letter);\
         return result;\
     }\
     if (value < 0) {\
         CHAR_TYPE const letter = '-';\
-        string_##CHAR_TYPE##_push_back(&result, &letter);\
+        SPECIALIZED_STRING_METHOD(CHAR_TYPE, push_back)(&result, &letter);\
         value = -value;\
     }\
     while (value) {\
         CHAR_TYPE const letter = value % 10 + '0';\
-        string_##CHAR_TYPE##_push_back(&result, &letter);\
+        SPECIALIZED_STRING_METHOD(CHAR_TYPE, push_back)(&result, &letter);\
         value /= 10;\
     }\
     /*reverse values*/\
-    uint const string_size = string_##CHAR_TYPE##_size(&result);\
+    uint const string_size = SPECIALIZED_STRING_METHOD(CHAR_TYPE, size)(&result);\
     for (uint index = 0u; index < string_size / 2; ++index) {\
-        CHAR_TYPE const temp = *string_##CHAR_TYPE##_at(&result, index);\
-        *string_##CHAR_TYPE##_mut_at(&result, index) = *string_##CHAR_TYPE##_at(&result, string_size - 1 - index);\
-        *string_##CHAR_TYPE##_mut_at(&result, string_size - 1 - index) = temp;\
+        CHAR_TYPE const temp = *SPECIALIZED_STRING_METHOD(CHAR_TYPE, at)(&result, index);\
+        *SPECIALIZED_STRING_METHOD(CHAR_TYPE, mut_at)(&result, index) = *SPECIALIZED_STRING_METHOD(CHAR_TYPE, at)(&result, string_size - 1 - index);\
+        *SPECIALIZED_STRING_METHOD(CHAR_TYPE, mut_at)(&result, string_size - 1 - index) = temp;\
     }\
     return result;\
 }\
@@ -43,8 +43,8 @@ struct string_##CHAR_TYPE utils__string__##NUMERIC_TYPE##_to_string_##CHAR_TYPE(
 #define DECLARE_COMPARE_STRING_TYPE_WITH_BUFFER(CHAR_TYPE)\
 int utils__string__compare_string_##CHAR_TYPE##_with_buffer(struct string_##CHAR_TYPE const* const this, uint buffer_size, CHAR_TYPE const* const buffer)
 #define IMPLEMENT_COMPARE_STRING_TYPE_WITH_BUFFER(CHAR_TYPE)\
-int utils__string__compare_string_##CHAR_TYPE##_with_buffer(struct string_##CHAR_TYPE const* const this, uint buffer_size, CHAR_TYPE const* const buffer) {\
-    uint const string_size = string_##CHAR_TYPE##_size(this);\
+int utils__string__compare_string_##CHAR_TYPE##_with_buffer(struct SPECIALIZED_STRING_TYPE(CHAR_TYPE) const* const this, uint buffer_size, CHAR_TYPE const* const buffer) {\
+    uint const string_size = SPECIALIZED_STRING_METHOD(CHAR_TYPE, size)(this);\
     if (string_size < buffer_size) {\
         return -1;\
     }\
@@ -52,7 +52,7 @@ int utils__string__compare_string_##CHAR_TYPE##_with_buffer(struct string_##CHAR
         return 1;\
     }\
     for (uint index = 0u; index < string_size; ++index) {\
-        CHAR_TYPE const * const value = string_##CHAR_TYPE##_at(this, index);\
+        CHAR_TYPE const * const value = SPECIALIZED_STRING_METHOD(CHAR_TYPE, at)(this, index);\
         if (*value < buffer[index]) {\
             return -1;\
         }\


### PR DESCRIPTION
- change macros' codegen
- add interface macro helpers (with example)
- fix hand-written methods/structs naming