### PR TITLE
feat destructors: change destructors return value from void to void*

### DIFF
--- a/src/construct/numeric_helpers.h
+++ b/src/construct/numeric_helpers.h
@@ -15,7 +15,7 @@ TYPE* TYPE_METHOD(TYPE, construct_copy_at)(TYPE* const ptr, TYPE const* const sr
 TYPE* TYPE_METHOD(TYPE, construct_move_at)(TYPE* const ptr, TYPE* const src)
 
 #define DECLARE_DESTROY_AT_FOR_NUMERIC_TYPE(TYPE) \
-void TYPE_METHOD(TYPE, destroy_at)(TYPE* const ptr)
+void* TYPE_METHOD(TYPE, destroy_at)(TYPE* const ptr)
 
 #define DECLARE_CONSTRUCTORS_AND_DESTRUCTORS_FOR_NUMERIC_TYPE(TYPE) \
 DECLARE_CONSTRUCT_AT_FOR_NUMERIC_TYPE(TYPE);\
@@ -41,7 +41,9 @@ TYPE* TYPE_METHOD(TYPE, construct_move_at)(TYPE* const ptr, TYPE* const src) { \
 }
 
 #define IMPLEMENT_DESTROY_AT_FOR_NUMERIC_TYPE(TYPE) \
-void TYPE_METHOD(TYPE, destroy_at)(TYPE* const ptr) {}
+void* TYPE_METHOD(TYPE, destroy_at)(TYPE* const ptr) { \
+	return ptr; \
+}
 
 #define IMPLEMENT_CONSTRUCTORS_AND_DESTRUCTORS_FOR_NUMERIC_TYPE(TYPE) \
 IMPLEMENT_CONSTRUCT_AT_FOR_NUMERIC_TYPE(TYPE);\

--- a/src/containers/array.h
+++ b/src/containers/array.h
@@ -20,7 +20,7 @@ ARRAY_STRUCT_TYPE(TYPE, SIZE)* ARRAY_METHOD(TYPE, SIZE, construct_at)(ARRAY_STRU
 ARRAY_STRUCT_TYPE(TYPE, SIZE)* ARRAY_METHOD(TYPE, SIZE, construct_copy_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this, ARRAY_STRUCT_TYPE(TYPE, SIZE) const* const source);\
 ARRAY_STRUCT_TYPE(TYPE, SIZE)* ARRAY_METHOD(TYPE, SIZE, construct_by_value_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this, TYPE const* const value);\
 ARRAY_STRUCT_TYPE(TYPE, SIZE)* ARRAY_METHOD(TYPE, SIZE, construct_from_buffer_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this, TYPE const (*buffer)[SIZE]);\
-void ARRAY_METHOD(TYPE, SIZE, destroy_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this);\
+void* ARRAY_METHOD(TYPE, SIZE, destroy_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this);\
 \
 uint ARRAY_METHOD(TYPE, SIZE, size)(ARRAY_STRUCT_TYPE(TYPE, SIZE) const* const this);\
 TYPE const* ARRAY_METHOD(TYPE, SIZE, data)(ARRAY_STRUCT_TYPE(TYPE, SIZE) const* const this);\
@@ -62,11 +62,12 @@ ARRAY_STRUCT_TYPE(TYPE, SIZE)* ARRAY_METHOD(TYPE, SIZE, construct_from_buffer_at
     }\
     return this;\
 }\
-void ARRAY_METHOD(TYPE, SIZE, destroy_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this){\
+void* ARRAY_METHOD(TYPE, SIZE, destroy_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this){\
     ASSERT(this);\
     for (uint index = 0u; index < SIZE; ++index) {\
         TYPE_METHOD(TYPE, destroy_at)(ARRAY_METHOD(TYPE, SIZE, mut_at)(this, index));\
     }\
+    return this;\
 }\
 \
 uint ARRAY_METHOD(TYPE, SIZE, size)(ARRAY_STRUCT_TYPE(TYPE, SIZE) const* const this) {\
@@ -94,7 +95,7 @@ static ARRAY_STRUCT_TYPE(TYPE, SIZE)* ARRAY_METHOD(TYPE, SIZE, construct_at)(ARR
 static ARRAY_STRUCT_TYPE(TYPE, SIZE)* ARRAY_METHOD(TYPE, SIZE, construct_copy_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this, ARRAY_STRUCT_TYPE(TYPE, SIZE) const* const source);\
 static ARRAY_STRUCT_TYPE(TYPE, SIZE)* ARRAY_METHOD(TYPE, SIZE, construct_by_value_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this, TYPE const* const value);\
 static ARRAY_STRUCT_TYPE(TYPE, SIZE)* ARRAY_METHOD(TYPE, SIZE, construct_from_buffer_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this, TYPE const (*buffer)[SIZE]);\
-static void ARRAY_METHOD(TYPE, SIZE, destroy_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this);\
+void* ARRAY_METHOD(TYPE, SIZE, destroy_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this);\
 \
 static uint ARRAY_METHOD(TYPE, SIZE, size)(ARRAY_STRUCT_TYPE(TYPE, SIZE) const* const this);\
 static TYPE const* ARRAY_METHOD(TYPE, SIZE, data)(ARRAY_STRUCT_TYPE(TYPE, SIZE) const* const this);\
@@ -133,11 +134,12 @@ static ARRAY_STRUCT_TYPE(TYPE, SIZE)* ARRAY_METHOD(TYPE, SIZE, construct_from_bu
     }\
     return this;\
 }\
-static void ARRAY_METHOD(TYPE, SIZE, destroy_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this){\
+void* ARRAY_METHOD(TYPE, SIZE, destroy_at)(ARRAY_STRUCT_TYPE(TYPE, SIZE)* const this){\
     ASSERT(this);\
     for (uint index = 0u; index < SIZE; ++index) {\
         TYPE_METHOD(TYPE, destroy_at)(ARRAY_METHOD(TYPE, SIZE, mut_at)(this, index));\
     }\
+    return this;\
 }\
 \
 static uint ARRAY_METHOD(TYPE, SIZE, size)(ARRAY_STRUCT_TYPE(TYPE, SIZE) const* const this) {\

--- a/src/containers/string.h
+++ b/src/containers/string.h
@@ -33,7 +33,7 @@ SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* SPECIALIZED_STRING_METHOD(TYPE, construct_
 SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* SPECIALIZED_STRING_METHOD(TYPE, construct_by_value_at)(SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const this, uint const size, TYPE const* const value);\
 SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* SPECIALIZED_STRING_METHOD(TYPE, construct_from_buffer_at)(SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const this, uint const buffer_size, TYPE const* const buffer);\
 SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* SPECIALIZED_STRING_METHOD(TYPE, construct_from_c_string_at)(SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const this, TYPE const* const buffer);\
-void SPECIALIZED_STRING_METHOD(TYPE, destroy_at)(SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const this);\
+void* SPECIALIZED_STRING_METHOD(TYPE, destroy_at)(SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const this);\
 /* --- Assignment functions implementation --- */\
 SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* SPECIALIZED_STRING_METHOD(TYPE, assign_move_from_string)(SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const this, SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const source);\
 SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* SPECIALIZED_STRING_METHOD(TYPE, assign_copy_from_string)(SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const this, SPECIALIZED_STRING_STRUCT_TYPE(TYPE) const* const source);\
@@ -117,10 +117,11 @@ SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* SPECIALIZED_STRING_METHOD(TYPE, construct_
     SPECIALIZED_STRING_METHOD(TYPE, construct_from_buffer_at)(this, buffer_size, buffer);\
     return this;\
 }\
-void SPECIALIZED_STRING_METHOD(TYPE, destroy_at)(SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const this) {\
+void* SPECIALIZED_STRING_METHOD(TYPE, destroy_at)(SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const this) {\
     if (!this->is_stack_allocated_) {\
         free(this->dynamic_data_.buffer_);\
     };\
+    return this;\
 }\
 /* --- Assignment functions implementation --- */\
 SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* SPECIALIZED_STRING_METHOD(TYPE, assign_move_from_string)(SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const this, SPECIALIZED_STRING_STRUCT_TYPE(TYPE)* const source) {\

--- a/src/tests/containers/array/array.c
+++ b/src/tests/containers/array/array.c
@@ -23,8 +23,9 @@ void TYPE_METHOD(test__inc_on_construction__dec_on_destruction, construct_copy_a
     ++*(this->encounter_pointer);
 }
 
-void TYPE_METHOD(test__inc_on_construction__dec_on_destruction, destroy_at)(test__inc_on_construction__dec_on_destruction* const this) {
+void* TYPE_METHOD(test__inc_on_construction__dec_on_destruction, destroy_at)(test__inc_on_construction__dec_on_destruction* const this) {
     --*(this->encounter_pointer);
+    return this;
 }
 
 #define TEST_BUFFER_SIZE4 275

--- a/src/utils/format.c
+++ b/src/utils/format.c
@@ -41,9 +41,10 @@ struct LOCAL_NAMESPACE(pattern)* PATTERN_FN(construct_copy_at)(struct LOCAL_NAME
     this->_type = src->_type;
     return this;
 }
-void PATTERN_FN(destroy_at)(struct LOCAL_NAMESPACE(pattern) * const this) {
+void* PATTERN_FN(destroy_at)(struct LOCAL_NAMESPACE(pattern) * const this) {
     ASSERT(this);
     STRING_METHOD(destroy_at)(&this->_string_representation);
+    return this;
 }
 
 struct LOCAL_NAMESPACE(pattern)* PATTERN_FN(construct_with_values_at)(struct LOCAL_NAMESPACE(pattern) * const this,
@@ -96,7 +97,7 @@ struct LOCAL_NAMESPACE(patterns) * PATTERNS_FN(construct_at)(struct LOCAL_NAMESP
     }
     return this;
 }
-struct LOCAL_NAMESPACE(patterns) * PATTERNS_FN(destroy_at)(struct LOCAL_NAMESPACE(patterns) * const this) {
+void* PATTERNS_FN(destroy_at)(struct LOCAL_NAMESPACE(patterns) * const this) {
     ASSERT(this);
     VECTOR_OF_PATTERNS * patterns = &this->_patterns;
     VECTOR_OF_PATTERNS_FN(destroy_at)(patterns);

--- a/src/utils/macros.h
+++ b/src/utils/macros.h
@@ -35,11 +35,8 @@ struct INTERFACE_VTABLE_TYPE(INTERFACE_NAME) const*/*const*/ INTERFACE_VTABLE_VA
 struct INTERFACE_TYPE(INTERFACE_NAME)/*const*/ INTERFACE_VARIABLE(INTERFACE_NAME)
 
 #define DEFINE_INTERFACE_TYPE_DYNAMIC_DISPOSE_METHODS(INTERFACE_NAME)\
-inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(INTERFACE_NAME), destroy_at)(struct INTERFACE_TYPE(INTERFACE_NAME)* const interface) {\
-    interface->INTERFACE_VTABLE_VARIABLE(INTERFACE_NAME)->destroy_at(interface);\
-}\
-inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(INTERFACE_NAME), deallocate_at)(struct INTERFACE_TYPE(INTERFACE_NAME)* const interface) {\
-    interface->INTERFACE_VTABLE_VARIABLE(INTERFACE_NAME)->deallocate_at(interface);\
+inline static void* TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(INTERFACE_NAME), destroy_at)(struct INTERFACE_TYPE(INTERFACE_NAME)* const interface) {\
+    return interface->INTERFACE_VTABLE_VARIABLE(INTERFACE_NAME)->destroy_at(interface);\
 }
 
 /*
@@ -52,8 +49,7 @@ inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(INTERFACE_NAME), deallocat
 * * 
 * * struct INTERFACE_VTABLE_TYPE(OnClick) {
 * *     void (*click)(struct INTERFACE_TYPE(OnClick)* const this);
-* *     void (*destroy_at)(struct INTERFACE_TYPE(OnClick)* const this);
-* *     void (*deallocate_at)(struct INTERFACE_TYPE(OnClick)* const this);
+* *     void* (*destroy_at)(struct INTERFACE_TYPE(OnClick)* const this);
 * * };
 * * 
 * * struct INTERFACE_TYPE(OnClick) {
@@ -61,8 +57,7 @@ inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(INTERFACE_NAME), deallocat
 * * };
 * * 
 * * struct INTERFACE_TYPE(OnClick)* TYPE_METHOD(INTERFACE_TYPE(OnClick), construct_at)(struct INTERFACE_TYPE(OnClick)* const this);
-* * void TYPE_MEMBER(INTERFACE_TYPE(OnClick), destroy_at)(struct INTERFACE_TYPE(OnClick)* const this);
-* * void TYPE_MEMBER(INTERFACE_TYPE(OnClick), deallocate_at)(struct INTERFACE_TYPE(OnClick)* const this);
+* * void* TYPE_MEMBER(INTERFACE_TYPE(OnClick), destroy_at)(struct INTERFACE_TYPE(OnClick)* const this);
 * * 
 * * inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(OnClick), click)(struct INTERFACE_TYPE(OnClick)* const this) {
 * *     this->INTERFACE_VTABLE_VARIABLE(OnClick)->click(this);
@@ -77,19 +72,16 @@ inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(INTERFACE_NAME), deallocat
 * * #include <stdlib.h>
 * * #include <stdio.h>
 * * 
-* * void TYPE_MEMBER(INTERFACE_TYPE(OnClick), destroy_at)(struct INTERFACE_TYPE(OnClick)* const this) {
+* * void* TYPE_MEMBER(INTERFACE_TYPE(OnClick), destroy_at)(struct INTERFACE_TYPE(OnClick)* const this) {
 * *     // method body
 * *     // ...
-* * }
-* * 
-* * void TYPE_MEMBER(INTERFACE_TYPE(OnClick), deallocate_at)(struct INTERFACE_TYPE(OnClick)* const this) {
-* *     free(this);
+* *     // boilerplate
+* *     return this;
 * * }
 * * 
 * * static struct INTERFACE_VTABLE_TYPE(OnClick) TYPE_MEMBER(INTERFACE_TYPE(OnClick), INTERFACE_VTABLE_VARIABLE(OnClick)) = {
 * *     .click = NULL,
-* *     .destroy_at = TYPE_MEMBER(INTERFACE_TYPE(OnClick), destroy_at),
-* *     .deallocate_at = TYPE_MEMBER(INTERFACE_TYPE(OnClick), deallocate_at)
+* *     .destroy_at = TYPE_MEMBER(INTERFACE_TYPE(OnClick), destroy_at)
 * * };
 * * 
 * * struct INTERFACE_TYPE(OnClick)* TYPE_METHOD(INTERFACE_TYPE(OnClick), construct_at)(struct INTERFACE_TYPE(OnClick)* const this) {
@@ -109,15 +101,10 @@ inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(INTERFACE_NAME), deallocat
 * * 
 * * struct Button* TYPE_METHOD(Button, construct_at)(struct Button* const this);
 * * struct INTERFACE_TYPE(OnClick)* INTERFACE_GETTER(Button, OnClick)(struct Button* const this);
-* * void TYPE_METHOD(Button, destroy_at)(struct Button* const this);
-* * inline static void TYPE_DYNAMIC_METHOD(Button, destroy_at)(struct Button* const this) {
+* * void* TYPE_METHOD(Button, destroy_at)(struct Button* const this);
+* * inline static void* TYPE_DYNAMIC_METHOD(Button, destroy_at)(struct Button* const this) {
 * *     // any interface with destroy_at is appropriate
-* *     TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(OnClick), destroy_at)(INTERFACE_GETTER(Button, OnClick)(this));
-* * }
-* * void TYPE_METHOD(Button, deallocate_at)(struct Button* const this);
-* * inline static void TYPE_DYNAMIC_METHOD(Button, deallocate_at)(struct Button* const this) {
-* *     // any interface with deallocate_at is appropriate
-* *     TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(OnClick), deallocate_at)(INTERFACE_GETTER(Button, OnClick)(this));
+* *     return TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(OnClick), destroy_at)(INTERFACE_GETTER(Button, OnClick)(this));
 * * }
 * *
 * button.c
@@ -126,26 +113,19 @@ inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(INTERFACE_NAME), deallocat
 * * #include <stdlib.h>
 * * #include <stdio.h>
 * * 
-* * void TYPE_METHOD(Button, destroy_at)(struct Button* const this) {
+* * void* TYPE_METHOD(Button, destroy_at)(struct Button* const this) {
 * *     printf("Button class destructor called\n");
 * * 
 * *     TYPE_METHOD(INTERFACE_TYPE(OnClick), destroy_at)(&this->INTERFACE_VARIABLE(OnClick));
-* * }
-* * 
-* * void TYPE_METHOD(Button, deallocate_at)(struct Button* const this) {
-* *     free(this);
+* *     return this;
 * * }
 * * 
 * * // OnClick overloading
 * * // fully boilerplated destroy_at
-* * static void TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), destroy_at))(struct INTERFACE_TYPE(OnClick)* const interface) {
-* *     TYPE_METHOD(Button, destroy_at)((struct Button* const)((void*)interface - offsetof(struct Button, INTERFACE_VARIABLE(OnClick))));
-* * }
-* * 
-* * // fully boilerplated deallocate_at
-* * void TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), deallocate_at))(struct INTERFACE_TYPE(OnClick)* const interface) {
+* * static void* TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), destroy_at))(struct INTERFACE_TYPE(OnClick)* const interface) {
 * *     struct Button* const this = (struct Button* const)((void*)interface - offsetof(struct Button, INTERFACE_VARIABLE(OnClick)));
-* *     TYPE_METHOD(Button, deallocate_at)(this);
+* *     TYPE_METHOD(Button, destroy_at)(this);
+* *     return this;
 * * }
 * * 
 * * void TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), click))(struct INTERFACE_TYPE(OnClick)* const interface) {
@@ -157,8 +137,7 @@ inline static void TYPE_DYNAMIC_METHOD(INTERFACE_TYPE(INTERFACE_NAME), deallocat
 * * 
 * * static struct INTERFACE_VTABLE_TYPE(OnClick) CONCAT3(Button, _, INTERFACE_VTABLE_VARIABLE(OnClick)) = {
 * *     .click = &TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), click)),
-* *     .destroy_at = &TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), destroy_at)),
-* *     .deallocate_at = &TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), deallocate_at))
+* *     .destroy_at = &TYPE_METHOD(Button, TYPE_METHOD(INTERFACE_TYPE(OnClick), destroy_at))
 * * };
 * * 
 * * struct INTERFACE_TYPE(OnClick)* INTERFACE_GETTER(Button, OnClick)(struct Button* const this) {


### PR DESCRIPTION
Change destructors return value from `void` to `void*` due new rule for deallocation logic for interfaces & others.
Now it is desirable for all destructors to have `void*` type as the return value and if destructor return void*, than that return value must have to point to original object.