### PR TITLE
Change build scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ if(WIN32)
         -Wall
         -Werror
         -Wno-unused-function
+        -Wno-c2x-compat # prevents boolean keywords compatibility error
         -Wno-declaration-after-statement
         -Wno-disabled-macro-expansion
         -fmacro-backtrace-limit=0)

--- a/build.bat
+++ b/build.bat
@@ -1,17 +1,24 @@
+@REM read arguments
 SET argument1=%~1
+
 @REM change directory to 'build.bat' file directory (project directory)
 cd /D "%~dp0"
+
 IF "%argument1%" == "" (
-    GOTO :build
-) 
-IF "%argument1%" == "-t" (
-    GOTO :tests
+    GOTO :plain_build
 )
-IF "%argument1%" == "--tests" (
-    GOTO :tests
+IF "%argument1%" == "-t" SET build_type=build_tests
+IF "%argument1%" == "--tests" SET build_type=build_tests
+IF "%argument1%" == "-e" SET build_type=run_tests
+IF "%argument1%" == "--exec-tests" SET build_type=run_tests
+
+IF defined build_type (
+    GOTO :build_tests
 )
+
 GOTO :eof
-:tests
+
+:build_tests
     @REM create sub-directory 'test' if it's not exists
     IF NOT EXIST .\build-tests (
         mkdir .\build-tests
@@ -22,10 +29,15 @@ GOTO :eof
     cmake -T ClangCL ..\tests
     @REM build project in Debug mode
     cmake --build .
+    @REM run tests if related option was set
+    IF %errorlevel% == 0 if "%build_type%" == "run_tests" (
+        ctest -C Debug --output-on-failure
+    )
     @REM go to project-directory
     cd ..
 GOTO :eof
-:build
+
+:plain_build
     @REM create sub-directory 'test' if it's not exists
     IF NOT EXIST .\build (
         mkdir .\build

--- a/src/primitives/bool_type_alias.h
+++ b/src/primitives/bool_type_alias.h
@@ -1,5 +1,18 @@
 #pragma once
 
+// C2x integrates these keywords: bool, true, false
+#if __STDC_VERSION__ < 202311L
+
+#ifndef bool
 typedef unsigned char bool;
+#endif
+
+#ifndef true
 #define true ((bool)1u)
+#endif
+
+#ifndef false
 #define false ((bool)0u)
+#endif
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ if(WIN32)
         -Wno-disabled-macro-expansion
         -fmacro-backtrace-limit=0)
 else()
-    target_link_options(${PROJECT_NAME} PRIVATE -lasan -lpthread -lm)
+    target_link_options(${PROJECT_NAME} PRIVATE -lpthread -lm -fsanitize=thread)
     target_compile_options(${PROJECT_NAME} PRIVATE
         -pedantic
         -Wall
@@ -41,7 +41,7 @@ else()
         -Wno-unused-function
         -Wno-declaration-after-statement
         -Wno-disabled-macro-expansion
-        -fsanitize=address
+        -fsanitize=thread
         -Wno-sequence-point
         -g)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ if(WIN32)
         -Wno-disabled-macro-expansion
         -fmacro-backtrace-limit=0)
 else()
-    target_link_options(${PROJECT_NAME} PRIVATE -lpthread -lm -fsanitize=thread)
+    target_link_options(${PROJECT_NAME} PRIVATE -lasan -lpthread -lm)
     target_compile_options(${PROJECT_NAME} PRIVATE
         -pedantic
         -Wall
@@ -41,7 +41,7 @@ else()
         -Wno-unused-function
         -Wno-declaration-after-statement
         -Wno-disabled-macro-expansion
-        -fsanitize=thread
+        -fsanitize=address
         -Wno-sequence-point
         -g)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ if(WIN32)
         -Wall
         -Werror
         -Wno-unused-function
+        -Wno-unsafe-buffer-usage # main function's argv array usage is trigger compile error
         -Wno-declaration-after-statement
         -Wno-disabled-macro-expansion
         -fmacro-backtrace-limit=0)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ else()
         -Wno-declaration-after-statement
         -Wno-disabled-macro-expansion
         -fsanitize=address
+        -O0
         -Wno-sequence-point
         -g)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ if(WIN32)
         -Werror
         -Wno-unused-function
         -Wno-unsafe-buffer-usage # main function's argv array usage is trigger compile error
+        -Wno-c2x-compat # prevents boolean keywords compatibility error
         -Wno-declaration-after-statement
         -Wno-disabled-macro-expansion
         -fmacro-backtrace-limit=0)


### PR DESCRIPTION
Changes:
- add `run_tests` additional option
- add `-Wno-unsafe-buffer-usage` option for msbuild tests
- add `-Wno-c2x-compat` to ignore error about definition of `bool`, `true`, `false` data types aliases
- add `-O0` as compiler option for tests' linux build pipeline (fixes errror on threads' tests with asan usage)
